### PR TITLE
[#63] Migrate project to jdk 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - openjdk8
+  - openjdk11
 install: true
 addons:
   sonarcloud:

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,42 @@
         <module>dss-example</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <java.version>11</java.version>
+                <access.option>--illegal-access=permit</access.option>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eluder.coveralls</groupId>
+                            <artifactId>coveralls-maven-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+            </properties>
+        </profile>
+    </profiles>
+
     <name>DSS PARENT</name>
     <description>Distributed server system</description>
     <url>https://github.com/ztkmkoo/dss</url>
@@ -92,7 +128,14 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.3</version>
+        </dependency>
     </dependencies>
+
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,8 @@
 
     <properties>
         <!-- Generic properties -->
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Dependencies version -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,42 +15,6 @@
         <module>dss-example</module>
     </modules>
 
-    <profiles>
-        <profile>
-            <id>jdk11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <java.version>11</java.version>
-                <access.option>--illegal-access=permit</access.option>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.eluder.coveralls</groupId>
-                            <artifactId>coveralls-maven-plugin</artifactId>
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <java.version>1.8</java.version>
-            </properties>
-        </profile>
-    </profiles>
-
     <name>DSS PARENT</name>
     <description>Distributed server system</description>
     <url>https://github.com/ztkmkoo/dss</url>
@@ -91,6 +55,28 @@
         </repository>
     </distributionManagement>
 
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <java.version>11</java.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.version>1.8</java.version>
+            </properties>
+        </profile>
+    </profiles>
+
     <properties>
         <!-- Generic properties -->
         <java.version>1.8</java.version>
@@ -103,7 +89,7 @@
         <awaitility.version>4.0.3</awaitility.version>
         <lombok.version>1.18.12</lombok.version>
         <coveralls.version>4.3.0</coveralls.version>
-        <jacoco.version>0.7.6.201602180812</jacoco.version>
+        <jacoco.version>0.8.3</jacoco.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 
@@ -128,14 +114,7 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.2.3</version>
-        </dependency>
     </dependencies>
-
 
     <build>
         <plugins>
@@ -143,6 +122,13 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>${coveralls.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Resolves #63 
Upgrade jdk 11 with maintaining jdk 1.8.

### Changes

- [x] add profiles to manage properties in pom.xml
  - jdk version
  - surefire configuration
- [x] add jdk 11 in travis.yml

### TEST
1. verify current profile (jdk11 or jdk8)
```bash
mvn help:active-profiles     
```
2. build & test
```
mvn install
```