### PR TITLE
[#90] NullPointerException in DssRestActorJsonService.java

### DIFF
--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/exception/DssRestRequestMappingException.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/exception/DssRestRequestMappingException.java
@@ -1,0 +1,17 @@
+package io.github.ztkmkoo.dss.core.actor.exception;
+
+public class DssRestRequestMappingException extends RuntimeException{
+    private static final long serialVersionUID = 6545592855014233698L;
+
+    public DssRestRequestMappingException(String message) {
+        super(message);
+    }
+
+    public DssRestRequestMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DssRestRequestMappingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/rest/DssRestServiceActor.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/rest/DssRestServiceActor.java
@@ -3,6 +3,7 @@ package io.github.ztkmkoo.dss.core.actor.rest;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
+import io.github.ztkmkoo.dss.core.actor.exception.DssRestRequestMappingException;
 import io.github.ztkmkoo.dss.core.actor.rest.entity.DssRestServiceResponse;
 import io.github.ztkmkoo.dss.core.actor.rest.service.DssRestActorService;
 import io.github.ztkmkoo.dss.core.message.rest.DssRestChannelHandlerCommandResponse;
@@ -53,6 +54,9 @@ public class DssRestServiceActor {
                         dssRestActorService.getConsume().getContentType(), request.getContentType());
                 replyRequest(request, HttpResponseStatus.BAD_REQUEST);
             }
+        } catch (DssRestRequestMappingException e) {
+            context.getLog().error("Json request mapping error: ", e);
+            replyRequest(request, HttpResponseStatus.BAD_REQUEST);
         } catch (Exception e) {
             context.getLog().error("Handling rest request error: ", e);
             replyRequest(request, HttpResponseStatus.INTERNAL_SERVER_ERROR);

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/rest/service/DssRestActorJsonService.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/actor/rest/service/DssRestActorJsonService.java
@@ -3,6 +3,7 @@ package io.github.ztkmkoo.dss.core.actor.rest.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.ztkmkoo.dss.core.actor.exception.DssRestRequestMappingException;
 import io.github.ztkmkoo.dss.core.actor.rest.entity.DssRestContentInfo;
 import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssRestContentType;
 import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssRestMethodType;
@@ -75,7 +76,7 @@ public abstract class DssRestActorJsonService<S extends Serializable> extends Ab
             final ObjectMapper mapper = new ObjectMapper();
             return mapper.readValue(content, typeReference);
         } catch (JsonProcessingException e) {
-            return null;
+            throw new DssRestRequestMappingException(e);
         }
     }
 


### PR DESCRIPTION
Resolves #90

fix json request mapping error

This is error log when an error occurs. and server responded with a 400 Bad request.
```
2020-08-04 16:14:00 [ERROR] [DssRestServiceActor.java]onHandlingDssRestServiceActorCommandRequest(58) : Json request mapping error: 
io.github.ztkmkoo.dss.core.actor.exception.DssRestJsonRequestMappingException: Unrecognized field "age" (class io.github.ztkmkoo.dss.server.rest.DssRestServerTest$TestJsonRequest), not marked as ignorable (one known property: "name"])
 at [Source: (String)"{"name":"myname","age":20}"; line: 1, column: 26] (through reference chain: io.github.ztkmkoo.dss.server.rest.DssRestServerTest$TestJsonRequest["age"])
	at io.github.ztkmkoo.dss.core.actor.rest.service.DssRestActorJsonService.getBody(DssRestActorJsonService.java:79)
	at io.github.ztkmkoo.dss.core.actor.rest.service.AbstractDssRestActorService.makeRequest(AbstractDssRestActorService.java:64)
	at io.github.ztkmkoo.dss.core.actor.rest.service.AbstractDssRestActorService.handling(AbstractDssRestActorService.java:57)
	at io.github.ztkmkoo.dss.core.actor.rest.DssRestServiceActor.onHandlingDssRestServiceActorCommandRequest(DssRestServiceActor.java:50)
	at akka.actor.typed.javadsl.BuiltBehavior.receive(BehaviorBuilder.scala:191)
	at akka.actor.typed.javadsl.BuiltBehavior.receive(BehaviorBuilder.scala:181)
	at akka.actor.typed.Behavior$.interpret(Behavior.scala:274)
	at akka.actor.typed.Behavior$.interpretMessage(Behavior.scala:230)
	at akka.actor.typed.internal.adapter.ActorAdapter.handleMessage(ActorAdapter.scala:126)
	at akka.actor.typed.internal.adapter.ActorAdapter.aroundReceive(ActorAdapter.scala:106)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:573)
	at akka.actor.ActorCell.invoke(ActorCell.scala:543)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:269)
	at akka.dispatch.Mailbox.run(Mailbox.scala:230)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:242)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
2020-08-04 16:14:00 [INFO ] [DssRestHandler.java]handlingDssRestChannelHandlerCommandResponse(210) : DssRestChannelHandlerCommandResponse: DssRestChannelHandlerCommandResponse{channelId: '380025fffe18c3d8-000023b4-00000001-1990c13ae41be037-1f532dc3', status: '400', response: 'null'}

```