### PR TITLE
[#97] bug fix: can't get response when using charset error.

### DIFF
--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/entity/DssRestRequest.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/entity/DssRestRequest.java
@@ -18,13 +18,15 @@ public class DssRestRequest implements Serializable {
     private static final long serialVersionUID = 8456589353995730809L;
     private final DssRestMethodType methodType;
     private final DssRestContentType contentType;
+    private final String charset;
     private final String uri;
     private final String content;
 
     @Builder
-    protected DssRestRequest(DssRestMethodType methodType, String uri, DssRestContentType contentType, String content) {
+    protected DssRestRequest(DssRestMethodType methodType, String uri, DssRestContentType contentType, String charset, String content) {
         this.methodType = methodType;
         this.contentType = contentType;
+        this.charset = charset;
         this.uri = uri;
         this.content = content;
     }

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
@@ -33,12 +33,12 @@ public enum DssRestContentType {
         this.text = text;
     }
 
-    public static DssRestContentType fromText(String text) {    	
-    	try{
+    public static DssRestContentType fromText(String text) {  
+    	if(Objects.nonNull(text)){
     		return textMap.get(text.split(";")[0]);
-    	}catch(NullPointerException e) {
-    		return textMap.get(text);
     	}
+    	
+    	return null;
     }
 
     private static Map<String, DssRestContentType> initTextMap() {

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
@@ -34,7 +34,7 @@ public enum DssRestContentType {
     }
 
     public static DssRestContentType fromText(String text) {
-        return textMap.get(text);
+    	return textMap.get(text.split(";")[0]);
     }
 
     private static Map<String, DssRestContentType> initTextMap() {

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/rest/enumeration/DssRestContentType.java
@@ -33,8 +33,12 @@ public enum DssRestContentType {
         this.text = text;
     }
 
-    public static DssRestContentType fromText(String text) {
-    	return textMap.get(text.split(";")[0]);
+    public static DssRestContentType fromText(String text) {    	
+    	try{
+    		return textMap.get(text.split(";")[0]);
+    	}catch(NullPointerException e) {
+    		return textMap.get(text);
+    	}
     }
 
     private static Map<String, DssRestContentType> initTextMap() {


### PR DESCRIPTION
Resolves #97 

fix bug when using charset in content type like 
curl -X GET -H "Content-Type: application/json; charset=utf-8" -d '{"name" : "myname"}' http://127.0.0.1:8181/my/service.

I just split content-type text into application/json and charset=utf-8.
And for setting charset, add charset member in DssRestRequest.