### PR TITLE
[#52] Add websocket handler 

### DIFF
--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/DssWebSocketChannel.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/DssWebSocketChannel.java
@@ -1,0 +1,31 @@
+package io.github.ztkmkoo.dss.core.network.websocket;
+
+import io.github.ztkmkoo.dss.core.network.DssChannel;
+import io.github.ztkmkoo.dss.core.network.websocket.handler.DssWebSocketChannelInitializer;
+import io.github.ztkmkoo.dss.core.network.websocket.property.DssWebSocketChannelProperty;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LoggingHandler;
+
+import java.util.Objects;
+
+public class DssWebSocketChannel implements DssChannel<DssWebSocketChannelProperty, DssWebSocketChannelInitializer> {
+
+    @Override
+    public Channel bind(ServerBootstrap serverBootstrap, DssWebSocketChannelProperty dssWebsocketChannelProperty,
+                        DssWebSocketChannelInitializer dssWebsocketChannelInitializer) throws InterruptedException {
+
+        Objects.requireNonNull(serverBootstrap);
+        Objects.requireNonNull(dssWebsocketChannelProperty);
+        Objects.requireNonNull(dssWebsocketChannelInitializer);
+
+        return serverBootstrap
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(dssWebsocketChannelProperty.getDssLogLevel().getNettyLogLevel()))
+                .childHandler(dssWebsocketChannelInitializer)
+                .bind(dssWebsocketChannelProperty.getHost(), dssWebsocketChannelProperty.getPort())
+                .sync()
+                .channel();
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandler.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandler.java
@@ -1,0 +1,142 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.*;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.websocketx.*;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.CharsetUtil;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.HttpMethod.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ChannelHandler.Sharable
+public class DssHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    private Logger logger = LoggerFactory.getLogger(DssHttpRequestHandler.class);
+
+    private final String WEBSOCKET_PATH;
+    private WebSocketServerHandshaker handshaker;
+
+    public DssHttpRequestHandler(String WEBSOCKET_PATH) {
+        this.WEBSOCKET_PATH = WEBSOCKET_PATH;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) throws Exception {
+        if (msg instanceof FullHttpRequest) {
+            final FullHttpRequest request = (FullHttpRequest) msg;
+            handleHttpRequest(ctx, request);
+        } else {
+            throw new UnsupportedOperationException("Unsupported Message Type " + msg.getClass().getName());
+        }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+
+    private void handleHttpRequest(ChannelHandlerContext ctx, FullHttpRequest req) throws InterruptedException {
+        final String uri = req.uri();
+        logger.info("Request URI: " + uri);
+
+        if (!req.decoderResult().isSuccess()) {
+            logger.info("BAD REQUEST");
+            sendHttpResponse(ctx, req, new DefaultFullHttpResponse(req.protocolVersion(), BAD_REQUEST, ctx.alloc().buffer(0)));
+            return;
+        }
+
+        if (!GET.equals(req.method())) {
+            logger.info("GET method is required");
+            sendHttpResponse(ctx, req, new DefaultFullHttpResponse(req.protocolVersion(), FORBIDDEN, ctx.alloc().buffer(0)));
+            return;
+        }
+
+        int baseIndex = uri.indexOf("?");
+        boolean checkEndPoint = baseIndex == -1 ? WEBSOCKET_PATH.equals(uri) : WEBSOCKET_PATH.equals(uri.substring(0, baseIndex));
+
+        if (checkEndPoint) {
+            logger.info("Request WebSocket Protocol");
+
+            HttpHeaders headers = req.headers();
+
+            if ("Upgrade".equalsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION)) &&
+                    "WebSocket".equalsIgnoreCase(headers.get(HttpHeaderNames.UPGRADE))) {
+                handleHandshake(ctx, req);
+                ctx.fireChannelRead(req.retain());
+            } else {
+                throw new InterruptedException("Websocket header field is needed");
+            }
+
+        } else if ("/".equals(req.uri())) {
+
+            ByteBuf content = req.content();
+            FullHttpResponse res = new DefaultFullHttpResponse(req.protocolVersion(), OK, content);
+
+            res.headers().set(CONTENT_TYPE, "text/html; charset=UTF-8");
+            HttpUtil.setContentLength(res, content.readableBytes());
+
+            sendHttpResponse(ctx, req, res);
+
+        } else {
+            logger.info("NOT FOUND");
+
+            sendHttpResponse(ctx, req, new DefaultFullHttpResponse(req.protocolVersion(), NOT_FOUND, ctx.alloc().buffer(0)));
+        }
+    }
+
+    private void handleHandshake(ChannelHandlerContext ctx, FullHttpRequest req) throws InterruptedException {
+        logger.info("Handshake Start");
+
+        String websocketURL = getWebSocketLocation(ctx.pipeline(), req, WEBSOCKET_PATH);
+        logger.info(websocketURL);
+
+        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(websocketURL, null, true);
+        handshaker = wsFactory.newHandshaker(req);
+        if (handshaker == null) {
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
+        } else {
+            handshaker.handshake(ctx.channel(), req).sync();
+            logger.info("Handshake Success");
+        }
+    }
+
+    private static void sendHttpResponse(ChannelHandlerContext ctx, FullHttpRequest req, FullHttpResponse res) {
+        HttpResponseStatus responseStatus = res.status();
+
+        if (responseStatus.code() != 200) {
+            ByteBuf buf = Unpooled.copiedBuffer(res.status().toString(), CharsetUtil.UTF_8);
+            res.content().writeBytes(buf);
+            buf.release();
+            HttpUtil.setContentLength(res, res.content().readableBytes());
+        }
+        boolean keepAlive = HttpUtil.isKeepAlive(req) && responseStatus.code() == 200;
+        HttpUtil.setKeepAlive(res, keepAlive);
+        ChannelFuture f = ctx.writeAndFlush(res.retain());
+        if (!keepAlive) {
+            f.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    private static String getWebSocketLocation(ChannelPipeline pipeline, HttpRequest request, String path) {
+        String protocol = "ws";
+
+        if (pipeline.get(SslHandler.class) != null) {
+            protocol = "wss";
+        }
+        return protocol + "://" + request.headers().get(HttpHeaderNames.HOST) + path;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logger.error("ExceptionCaught", cause);
+
+        ctx.close();
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandler.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandler.java
@@ -22,6 +22,7 @@ public class DssHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpR
 
     private final String WEBSOCKET_PATH;
     private WebSocketServerHandshaker handshaker;
+    private FullHttpRequest request;
 
     public DssHttpRequestHandler(String WEBSOCKET_PATH) {
         this.WEBSOCKET_PATH = WEBSOCKET_PATH;
@@ -29,8 +30,8 @@ public class DssHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpR
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) throws Exception {
-        if (msg instanceof FullHttpRequest) {
-            final FullHttpRequest request = (FullHttpRequest) msg;
+        if (msg != null) {
+            request = msg;
             handleHttpRequest(ctx, request);
         } else {
             throw new UnsupportedOperationException("Unsupported Message Type " + msg.getClass().getName());
@@ -38,7 +39,7 @@ public class DssHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpR
     }
 
     @Override
-    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+    public void channelReadComplete(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 
@@ -134,7 +135,7 @@ public class DssHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpR
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         logger.error("ExceptionCaught", cause);
 
         ctx.close();

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketChannelInitializer.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketChannelInitializer.java
@@ -1,0 +1,29 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DssWebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final Logger logger = LoggerFactory.getLogger(DssWebSocketChannelInitializer.class);
+
+    private final String WEBSOCKET_PATH = "/websocket";
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        logger.info("Try to initChannel");
+
+        final ChannelPipeline p = ch.pipeline();
+
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(65536));
+        p.addLast(new DssHttpRequestHandler(WEBSOCKET_PATH));
+        p.addLast(new DssWebSocketHandler());
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandler.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandler.java
@@ -8,13 +8,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DssWebSocketHandler extends ChannelInboundHandlerAdapter {
+
     private final Logger logger = LoggerFactory.getLogger(DssWebSocketHandler.class);
+    private TextWebSocketFrame message;
+    private CloseWebSocketFrame closeMessage;
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
 
         if (msg instanceof WebSocketFrame) {
-            logger.info("Client Channel : " + ctx.channel());
+            logger.info("Client Channel : {}", ctx.channel());
 
             if (msg instanceof BinaryWebSocketFrame) {
                 logger.info("BinaryWebSocketFrame Received");
@@ -22,10 +25,10 @@ public class DssWebSocketHandler extends ChannelInboundHandlerAdapter {
             } else if (msg instanceof TextWebSocketFrame) {
                 logger.info("TextWebSocketFrame Received");
 
-                final TextWebSocketFrame textWebSocketFrame =  (TextWebSocketFrame) msg;
-                ctx.channel().writeAndFlush(textWebSocketFrame.text());
+                message =  (TextWebSocketFrame) msg;
+                ctx.channel().writeAndFlush(message.text());
 
-                logger.info("Received Message : " + textWebSocketFrame.text());
+                logger.info("Received Message : {}", message.text());
             } else if (msg instanceof PingWebSocketFrame) {
                 logger.info("PingWebSocketFrame Received");
 
@@ -35,12 +38,23 @@ public class DssWebSocketHandler extends ChannelInboundHandlerAdapter {
             } else if (msg instanceof CloseWebSocketFrame) {
                 logger.info("CloseWebSocketFrame Received");
 
-                final CloseWebSocketFrame closeWebSocketFrame = (CloseWebSocketFrame) msg;
-                logger.info("ReasonText : " + closeWebSocketFrame.reasonText());
-                logger.info("StatusCode : " + closeWebSocketFrame.statusCode());
+                closeMessage = (CloseWebSocketFrame) msg;
+                logger.info("ReasonText : {}", closeMessage.reasonText());
+                logger.info("StatusCode : {}", closeMessage.statusCode());
             } else {
                 throw new UnsupportedOperationException("Unsupported WebSocketFrame Type " + msg.getClass().getName());
             }
         }
+    }
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        logger.error("exceptionCaught", cause);
+
+        ctx.close();
     }
 }

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandler.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandler.java
@@ -1,0 +1,46 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.websocketx.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DssWebSocketHandler extends ChannelInboundHandlerAdapter {
+    private final Logger logger = LoggerFactory.getLogger(DssWebSocketHandler.class);
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+
+        if (msg instanceof WebSocketFrame) {
+            logger.info("Client Channel : " + ctx.channel());
+
+            if (msg instanceof BinaryWebSocketFrame) {
+                logger.info("BinaryWebSocketFrame Received");
+
+            } else if (msg instanceof TextWebSocketFrame) {
+                logger.info("TextWebSocketFrame Received");
+
+                final TextWebSocketFrame textWebSocketFrame =  (TextWebSocketFrame) msg;
+                ctx.channel().writeAndFlush(textWebSocketFrame.text());
+
+                logger.info("Received Message : " + textWebSocketFrame.text());
+            } else if (msg instanceof PingWebSocketFrame) {
+                logger.info("PingWebSocketFrame Received");
+
+            } else if (msg instanceof PongWebSocketFrame) {
+                logger.info("PongWebSocketFrame Received");
+
+            } else if (msg instanceof CloseWebSocketFrame) {
+                logger.info("CloseWebSocketFrame Received");
+
+                final CloseWebSocketFrame closeWebSocketFrame = (CloseWebSocketFrame) msg;
+                logger.info("ReasonText : " + closeWebSocketFrame.reasonText());
+                logger.info("StatusCode : " + closeWebSocketFrame.statusCode());
+            } else {
+                throw new UnsupportedOperationException("Unsupported WebSocketFrame Type " + msg.getClass().getName());
+            }
+        }
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketSslChannelInitializer.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketSslChannelInitializer.java
@@ -1,0 +1,51 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+import javax.net.ssl.SSLException;
+import java.security.cert.CertificateException;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DssWebSocketSslChannelInitializer extends DssWebSocketChannelInitializer {
+
+    private final Logger logger = LoggerFactory.getLogger(DssWebSocketSslChannelInitializer.class);
+
+    private final String WEBSOCKET_PATH = "/websocket";
+    private final SslContext sslCtx;
+
+    public DssWebSocketSslChannelInitializer(SslContext sslCtx) throws InterruptedException {
+        this.sslCtx = Objects.nonNull(sslCtx) ? sslCtx : selfSignedSslContext();
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        logger.info("Try to initChannel");
+
+        final ChannelPipeline p = ch.pipeline();
+
+        p.addLast(sslCtx.newHandler(ch.alloc()));
+
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(65536));
+        p.addLast(new DssHttpRequestHandler(WEBSOCKET_PATH));
+        p.addLast(new DssWebSocketHandler());
+    }
+
+    private static SslContext selfSignedSslContext() throws InterruptedException {
+        try {
+            final SelfSignedCertificate ssc = new SelfSignedCertificate();
+            return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+        } catch (CertificateException | SSLException e) {
+            throw new InterruptedException("Create self signed ssl context failed");
+        }
+    }
+}

--- a/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/property/DssWebSocketChannelProperty.java
+++ b/dss-core/src/main/java/io/github/ztkmkoo/dss/core/network/websocket/property/DssWebSocketChannelProperty.java
@@ -1,0 +1,26 @@
+package io.github.ztkmkoo.dss.core.network.websocket.property;
+
+import io.github.ztkmkoo.dss.core.network.DssChannelProperty;
+import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssLogLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+public class DssWebSocketChannelProperty implements Serializable, DssChannelProperty {
+
+    private static final long serialVersionUID = -2235406911031269400L;
+
+    private final String host;
+    private final int port;
+    private final DssLogLevel dssLogLevel;
+
+    @Builder
+    public DssWebSocketChannelProperty(String host, int port, DssLogLevel dssLogLevel) {
+        this.host = host;
+        this.port = port;
+        this.dssLogLevel = Objects.nonNull(dssLogLevel) ? dssLogLevel : DssLogLevel.DEBUG;
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/DssWebSocketChannelTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/DssWebSocketChannelTest.java
@@ -1,0 +1,53 @@
+package io.github.ztkmkoo.dss.core.network.websocket;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import io.github.ztkmkoo.dss.core.network.websocket.handler.DssWebSocketChannelInitializer;
+import io.github.ztkmkoo.dss.core.network.websocket.property.DssWebSocketChannelProperty;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import org.junit.jupiter.api.Test;
+
+class DssWebSocketChannelTest {
+
+    @Test
+    void bind() throws Exception {
+
+        final EventLoopGroup bossGroup = new NioEventLoopGroup();
+        final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+        final ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup);
+
+        final DssWebSocketChannelProperty property = DssWebSocketChannelProperty
+                .builder()
+                .host("127.0.0.1")
+                .port(8181)
+                .build();
+
+        final DssWebSocketChannelInitializer channelInitializer = new DssWebSocketChannelInitializer();
+
+        try {
+            final DssWebSocketChannel dssWebSocketChannel = new DssWebSocketChannel();
+            final Channel channel = dssWebSocketChannel.bind(bootstrap, property, channelInitializer);
+
+            final Socket socket = new Socket();
+            socket.connect(new InetSocketAddress("127.0.0.1", 8181));
+
+            assertTrue(socket.isConnected());
+
+            channel.close().sync();
+        } finally {
+            assertNotNull(workerGroup);
+            workerGroup.shutdownGracefully();
+
+            assertNotNull(bossGroup);
+            bossGroup.shutdownGracefully();
+        }
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandlerTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssHttpRequestHandlerTest.java
@@ -1,0 +1,128 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.*;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+class DssHttpRequestHandlerTest {
+
+    private final String WEBSOCKET_PATH = "/websocket";
+
+    private static <T> T getDssHttpRequestHandlerFieldWithReflection(DssHttpRequestHandler handler, String fieldName, Class<T> tcLass) throws NoSuchFieldException, IllegalAccessException {
+
+        final Field field = DssHttpRequestHandler.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return tcLass.cast(field.get(handler));
+    }
+
+    private static void mockChannelHandlerContextChannelId(ChannelHandlerContext ctx, String longId) {
+
+        final Channel mockChannel = Mockito.mock(Channel.class);
+        final ChannelId channelId = Mockito.mock(ChannelId.class);
+        final ChannelPipeline pipeline = Mockito.mock(ChannelPipeline.class);
+        final ChannelPromise promise = Mockito.mock(ChannelPromise.class);
+
+        Mockito.when(ctx.channel()).thenReturn(mockChannel);
+        Mockito.when(ctx.pipeline()).thenReturn(pipeline);
+        Mockito.when(ctx.channel().pipeline()).thenReturn(pipeline);
+        Mockito.when(ctx.channel().newPromise()).thenReturn(promise);
+        Mockito.when(mockChannel.id()).thenReturn(channelId);
+        Mockito.when(channelId.asLongText()).thenReturn(longId);
+    }
+
+    private final FullHttpRequest websocketRequest = requestWebsocket();
+    private final ByteBuf content = Unpooled.copiedBuffer("Hello", CharsetUtil.UTF_8);
+    private final FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/", content);
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void channelRead() throws Exception {
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssHttpRequestHandler handler = new DssHttpRequestHandler(WEBSOCKET_PATH);
+
+        handler.channelRead(ctx, httpRequest);
+
+        final FullHttpRequest request = getDssHttpRequestHandlerFieldWithReflection(handler, "request", FullHttpRequest.class);
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals("/", request.uri());
+        assertEquals("Hello", request.content().toString(Charset.defaultCharset()));
+
+        handler.channelRead(ctx, websocketRequest);
+
+        final FullHttpRequest wsRequest = getDssHttpRequestHandlerFieldWithReflection(handler, "request", FullHttpRequest.class);
+        assertEquals(HttpVersion.HTTP_1_1, wsRequest.protocolVersion());
+        assertEquals(HttpMethod.GET, wsRequest.method());
+        assertEquals("/websocket", wsRequest.uri());
+        assertEquals("websocket", wsRequest.headers().get("Upgrade").toLowerCase());
+        assertEquals("upgrade", wsRequest.headers().get("Connection").toLowerCase());
+        assertEquals("dGhlIHNhbXBsZSBub25jZQ==", wsRequest.headers().get("Sec-WebSocket-Key"));
+        assertEquals("http://test.com", wsRequest.headers().get("Sec-WebSocket-Origin"));
+        assertEquals("13", wsRequest.headers().get("Sec-WebSocket-Version"));
+
+        final WebSocketServerHandshaker handshaker = getDssHttpRequestHandlerFieldWithReflection(handler, "handshaker", WebSocketServerHandshaker.class);
+        assertEquals("ws://dss.test.com/websocket", handshaker.uri());
+        assertEquals("13", handshaker.version().toHttpHeaderValue());
+
+    }
+
+    @Test
+    void channelReadComplete() throws Exception {
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssHttpRequestHandler handler = new DssHttpRequestHandler(WEBSOCKET_PATH);
+
+        handler.channelRead(ctx, websocketRequest);
+
+        handler.channelReadComplete(ctx);
+
+        Mockito.verify(ctx).flush();
+    }
+
+    @Test
+    void exceptionCaught() {
+
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssHttpRequestHandler handler = new DssHttpRequestHandler(WEBSOCKET_PATH);
+
+        handler.exceptionCaught(ctx, new NullPointerException());
+
+        assertTrue(true);
+    }
+
+    private FullHttpRequest requestWebsocket() {
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, WEBSOCKET_PATH, Unpooled.EMPTY_BUFFER);
+        HttpHeaders headers = request.headers();
+
+        headers.set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
+                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                .set(HttpHeaderNames.HOST, "dss.test.com")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://test.com")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+
+        return request;
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketChannelInitializerTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketChannelInitializerTest.java
@@ -1,0 +1,67 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.any;
+
+class DssWebSocketChannelInitializerTest {
+
+    @Mock
+    private SocketChannel socketChannel;
+
+    @Mock
+    private ChannelPipeline channelPipeline;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void initChannel() throws Exception {
+
+        Mockito
+                .when(socketChannel.pipeline())
+                .thenReturn(channelPipeline);
+
+        Mockito
+                .when(channelPipeline.addLast(any()))
+                .thenReturn(channelPipeline);
+
+        Mockito
+                .when(channelPipeline.first())
+                .thenReturn(new HttpServerCodec());
+
+        Mockito
+                .when(channelPipeline.get(HttpObjectAggregator.class))
+                .thenReturn(new HttpObjectAggregator(65536));
+
+        Mockito
+                .when(channelPipeline.get(DssHttpRequestHandler.class))
+                .thenReturn(new DssHttpRequestHandler("/websocket"));
+
+        Mockito
+                .when(channelPipeline.last())
+                .thenReturn(new DssWebSocketHandler());
+
+        final DssWebSocketChannelInitializer dssWebSocketChannelInitializer = Mockito.mock(DssWebSocketChannelInitializer.class);
+
+        dssWebSocketChannelInitializer.initChannel(socketChannel);
+
+        final ChannelPipeline p = socketChannel.pipeline();
+
+        assertEquals(HttpServerCodec.class, p.first().getClass());
+        assertEquals(HttpObjectAggregator.class, p.get(HttpObjectAggregator.class).getClass());
+        assertEquals(DssHttpRequestHandler.class, p.get(DssHttpRequestHandler.class).getClass());
+        assertEquals(DssWebSocketHandler.class, p.last().getClass());
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandlerTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketHandlerTest.java
@@ -1,0 +1,95 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelId;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+
+class DssWebSocketHandlerTest {
+
+    private static <T> T getDssWebSocketHandlerFieldWithReflection(DssWebSocketHandler handler, String fieldName, Class<T> tcLass) throws NoSuchFieldException, IllegalAccessException {
+
+        final Field field = DssWebSocketHandler.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return tcLass.cast(field.get(handler));
+    }
+
+    private static void mockChannelHandlerContextChannelId(ChannelHandlerContext ctx, String longId) {
+
+        final Channel mockChannel = Mockito.mock(Channel.class);
+        final ChannelId channelId = Mockito.mock(ChannelId.class);
+
+        Mockito.when(ctx.channel()).thenReturn(mockChannel);
+        Mockito.when(mockChannel.id()).thenReturn(channelId);
+        Mockito.when(channelId.asLongText()).thenReturn(longId);
+    }
+
+    private final TextWebSocketFrame message = new TextWebSocketFrame("Hello");
+    private final CloseWebSocketFrame closeMessage = new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE);
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void channelRead() throws Exception {
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssWebSocketHandler handler = new DssWebSocketHandler();
+
+        handler.channelRead(ctx, message);
+
+        final TextWebSocketFrame msg = getDssWebSocketHandlerFieldWithReflection(handler, "message", TextWebSocketFrame.class);
+        assertEquals("Hello", msg.text());
+
+        handler.channelRead(ctx, closeMessage);
+
+        final CloseWebSocketFrame closeMsg = getDssWebSocketHandlerFieldWithReflection(handler, "closeMessage", CloseWebSocketFrame.class);
+        assertEquals("Bye", closeMsg.reasonText());
+        assertEquals(1000, closeMsg.statusCode());
+    }
+
+    @Test
+    void channelReadComplete() {
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssWebSocketHandler handler = new DssWebSocketHandler();
+
+        handler.channelRead(ctx, message);
+
+        handler.channelReadComplete(ctx);
+
+        Mockito.verify(ctx).flush();
+    }
+
+    @Test
+    void exceptionCaught() {
+
+        mockChannelHandlerContextChannelId(ctx, "abcedf");
+
+        final DssWebSocketHandler handler = new DssWebSocketHandler();
+
+        handler.exceptionCaught(ctx, new NullPointerException());
+
+        assertTrue(true);
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketSslChannelInitializerTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/handler/DssWebSocketSslChannelInitializerTest.java
@@ -1,0 +1,78 @@
+package io.github.ztkmkoo.dss.core.network.websocket.handler;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.ssl.SslHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.net.ssl.SSLEngine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.any;
+
+class DssWebSocketSslChannelInitializerTest {
+
+    @Mock
+    private SocketChannel socketChannel;
+
+    @Mock
+    private ChannelPipeline channelPipeline;
+
+    @Mock
+    private SSLEngine sslEngine;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void initChannel() throws Exception {
+
+        Mockito
+                .when(socketChannel.pipeline())
+                .thenReturn(channelPipeline);
+
+        Mockito
+                .when(channelPipeline.addLast(any()))
+                .thenReturn(channelPipeline);
+
+        Mockito
+                .when(channelPipeline.first())
+                .thenReturn(new SslHandler(sslEngine));
+
+        Mockito
+                .when(channelPipeline.get(HttpServerCodec.class))
+                .thenReturn(new HttpServerCodec());
+
+        Mockito
+                .when(channelPipeline.get(HttpObjectAggregator.class))
+                .thenReturn(new HttpObjectAggregator(65536));
+
+        Mockito
+                .when(channelPipeline.get(DssHttpRequestHandler.class))
+                .thenReturn(new DssHttpRequestHandler("/websocket"));
+
+        Mockito
+                .when(channelPipeline.last())
+                .thenReturn(new DssWebSocketHandler());
+
+        final DssWebSocketSslChannelInitializer dssWebSocketSslChannelInitializerTest = Mockito.mock(DssWebSocketSslChannelInitializer.class);
+
+        dssWebSocketSslChannelInitializerTest.initChannel(socketChannel);
+
+        final ChannelPipeline p = socketChannel.pipeline();
+
+        assertEquals(SslHandler.class, p.first().getClass());
+        assertEquals(HttpServerCodec.class, p.get(HttpServerCodec.class).getClass());
+        assertEquals(HttpObjectAggregator.class, p.get(HttpObjectAggregator.class).getClass());
+        assertEquals(DssHttpRequestHandler.class, p.get(DssHttpRequestHandler.class).getClass());
+        assertEquals(DssWebSocketHandler.class, p.last().getClass());
+    }
+}

--- a/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/property/DssWebSocketChannelPropertyTest.java
+++ b/dss-core/src/test/java/io/github/ztkmkoo/dss/core/network/websocket/property/DssWebSocketChannelPropertyTest.java
@@ -1,0 +1,22 @@
+package io.github.ztkmkoo.dss.core.network.websocket.property;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class DssWebSocketChannelPropertyTest {
+
+    @Test
+    void builder() {
+
+        final DssWebSocketChannelProperty property = DssWebSocketChannelProperty
+                .builder()
+                .host("127.0.0.1")
+                .port(8080)
+                .build();
+
+        assertNotNull(property);
+        assertEquals("127.0.0.1", property.getHost());
+        assertEquals(8080, property.getPort());
+    }
+}

--- a/dss-server/pom.xml
+++ b/dss-server/pom.xml
@@ -36,6 +36,7 @@
 	<properties>
         <!-- Dependencies version -->
         <akka.version>2.6.3</akka.version>
+        <jetty.version>9.4.14.v20181114</jetty.version>
     </properties>
     <dependencies>
         <!--dss core model-->
@@ -62,6 +63,16 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-client-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
     </dependencies>
 

--- a/dss-server/src/main/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServer.java
+++ b/dss-server/src/main/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServer.java
@@ -1,6 +1,5 @@
 package io.github.ztkmkoo.dss.server.websocket;
 
-import akka.actor.ActorSystem;
 import io.github.ztkmkoo.dss.core.actor.DssActorService;
 import io.github.ztkmkoo.dss.core.exception.handler.DssExceptionHandler;
 import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssLogLevel;
@@ -14,12 +13,11 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.SslContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DssWebSocketServer implements DssServer {
 
@@ -33,7 +31,6 @@ public class DssWebSocketServer implements DssServer {
     private final AtomicBoolean shutdown = new AtomicBoolean(true);
 
     private Channel channel;
-    private ActorSystem system;
 
     public DssWebSocketServer(String host, int port) { this(host, port, DssLogLevel.DEBUG, false,null); }
 
@@ -81,24 +78,7 @@ public class DssWebSocketServer implements DssServer {
             logger.info("Channel try to close. [Active: {}][Open: {}]", channel.isActive(), channel.isOpen());
             channel.close();
             active.set(false);
-        }
-
-        if (Objects.nonNull(system)) {
-            logger.info("Actor system try to terminate");
-            system.terminate();
-
-            final int waitMaxSecond = 10;
-            int count = 0;
-            while (count++ < waitMaxSecond) {
-                Thread.sleep(1000);
-                if (system.whenTerminated().isCompleted()) {
-                    break;
-                }
-            }
-
-            if (!system.whenTerminated().isCompleted()) {
-                logger.error("Cannot terminate actor system.");
-            }
+            shutdown.set(true);
         }
     }
 

--- a/dss-server/src/main/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServer.java
+++ b/dss-server/src/main/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServer.java
@@ -1,0 +1,135 @@
+package io.github.ztkmkoo.dss.server.websocket;
+
+import akka.actor.ActorSystem;
+import io.github.ztkmkoo.dss.core.actor.DssActorService;
+import io.github.ztkmkoo.dss.core.exception.handler.DssExceptionHandler;
+import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssLogLevel;
+import io.github.ztkmkoo.dss.core.network.websocket.DssWebSocketChannel;
+import io.github.ztkmkoo.dss.core.network.websocket.handler.DssWebSocketChannelInitializer;
+import io.github.ztkmkoo.dss.core.network.websocket.handler.DssWebSocketSslChannelInitializer;
+import io.github.ztkmkoo.dss.core.network.websocket.property.DssWebSocketChannelProperty;
+import io.github.ztkmkoo.dss.server.DssServer;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.ssl.SslContext;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DssWebSocketServer implements DssServer {
+
+    private final DssLogLevel dssLogLevel;
+    private final Logger logger = LoggerFactory.getLogger(DssWebSocketServer.class);
+    private final String host;
+    private final int port;
+    private final boolean ssl;
+    private final SslContext sslContext;
+    private final AtomicBoolean active = new AtomicBoolean(false);
+    private final AtomicBoolean shutdown = new AtomicBoolean(true);
+
+    private Channel channel;
+    private ActorSystem system;
+
+    public DssWebSocketServer(String host, int port) { this(host, port, DssLogLevel.DEBUG, false,null); }
+
+    public DssWebSocketServer(String host, int port, DssLogLevel dssLogLevel) { this(host, port, dssLogLevel, false, null); }
+
+    public DssWebSocketServer(String host, int port, DssLogLevel dssLogLevel, boolean ssl, SslContext sslContext) {
+        this.host = host;
+        this.port = port;
+        this.dssLogLevel = Objects.nonNull(dssLogLevel) ? dssLogLevel : DssLogLevel.DEBUG;
+        this.ssl = ssl;
+        this.sslContext = sslContext;
+    }
+
+    @Override
+    public void start() throws InterruptedException {
+        final DssWebSocketChannelInitializer channelInitializer = dssWebsocketChannelInitializer();
+
+        final EventLoopGroup bossGroup = new NioEventLoopGroup();
+        final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+        final ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup);
+
+        final DssWebSocketChannelProperty property = newDssWebsocketChannelProperty();
+
+        try {
+            final DssWebSocketChannel dssWebsocketChannel = new DssWebSocketChannel();
+            channel = dssWebsocketChannel.bind(bootstrap, property, channelInitializer);
+            active.set(true);
+            shutdown.set(false);
+            logger.info("Server Started");
+            channel.closeFuture().sync();
+        } finally {
+            logger.info("Shut down worker and boss group gracefully");
+            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully();
+            shutdown.set(true);
+        }
+
+    }
+
+    @Override
+    public void stop() throws InterruptedException {
+        if (Objects.nonNull(channel)) {
+            logger.info("Channel try to close. [Active: {}][Open: {}]", channel.isActive(), channel.isOpen());
+            channel.close();
+            active.set(false);
+        }
+
+        if (Objects.nonNull(system)) {
+            logger.info("Actor system try to terminate");
+            system.terminate();
+
+            final int waitMaxSecond = 10;
+            int count = 0;
+            while (count++ < waitMaxSecond) {
+                Thread.sleep(1000);
+                if (system.whenTerminated().isCompleted()) {
+                    break;
+                }
+            }
+
+            if (!system.whenTerminated().isCompleted()) {
+                logger.error("Cannot terminate actor system.");
+            }
+        }
+    }
+
+    @Override
+    public boolean isActivated() {
+        return active.get();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown.get();
+    }
+
+    @Override
+    public DssServer addDssService(DssActorService service) {
+        return null;
+    }
+
+    @Override
+    public DssServer addExceptionHandler(DssExceptionHandler exceptionHandler) { return null; }
+
+    private DssWebSocketChannelProperty newDssWebsocketChannelProperty() {
+        return DssWebSocketChannelProperty
+                .builder()
+                .host(host)
+                .port(port)
+                .dssLogLevel(dssLogLevel)
+                .build();
+    }
+
+    private DssWebSocketChannelInitializer dssWebsocketChannelInitializer() throws InterruptedException {
+        return ssl ? new DssWebSocketSslChannelInitializer(sslContext) : new DssWebSocketChannelInitializer();
+    }
+}

--- a/dss-server/src/test/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServerTest.java
+++ b/dss-server/src/test/java/io/github/ztkmkoo/dss/server/websocket/DssWebSocketServerTest.java
@@ -1,0 +1,231 @@
+package io.github.ztkmkoo.dss.server.websocket;
+
+import io.github.ztkmkoo.dss.core.network.rest.enumeration.DssLogLevel;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.UpgradeResponse;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DssWebSocketServerTest {
+
+    private static final String SSL_PASSWORD = "dss123";
+
+    private static void startOnNewThread(Runnable runnable) {
+        new Thread(runnable).start();
+    }
+
+    private static void stopDssWebSocketServerAfterActivated(DssWebSocketServer dssWebSocketServer, int waitStartupSeconds, int waitShutdownSeconds) {
+        startOnNewThread(() -> {
+            try {
+                await()
+                        .atMost(waitStartupSeconds, TimeUnit.SECONDS)
+                        .until(dssWebSocketServer::isActivated);
+                dssWebSocketServer.stop();
+
+                await()
+                        .atMost(waitShutdownSeconds, TimeUnit.SECONDS)
+                        .until(dssWebSocketServer::isShutdown);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private static PrivateKey loadPrivateKeyFromFile(File file) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        final FileInputStream fis = new FileInputStream(file);
+        final byte[] buffer = new byte[fis.available()];
+        fis.read(buffer);
+        fis.close();
+
+        final KeySpec keySpec = new PKCS8EncodedKeySpec(buffer);
+        final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePrivate(keySpec);
+    }
+
+    private static X509Certificate loadX509CertificateFromFile(File file) throws IOException, CertificateException {
+        final FileInputStream fis = new FileInputStream(file);
+        final byte[] buffer = new byte[fis.available()];
+        fis.read(buffer);
+        fis.close();
+
+        final ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+
+        final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        return (X509Certificate)factory.generateCertificate(bais);
+    }
+
+    private static File loadFromTestResources(String path) throws UnsupportedEncodingException {
+        final ClassLoader classLoader = DssWebSocketServerTest.class.getClassLoader();
+        return new File(URLDecoder.decode(classLoader.getResource(path).getFile(),"UTF-8"));
+    }
+
+    private static void startOnDssTextWebSocketServer(DssWebSocketServer dssWebSocketServer) {
+        startOnNewThread(() -> {
+            try {
+                dssWebSocketServer.start();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private static HttpResponse sendTextRequest(String uri, HttpMethod method, String sendTextBody) throws IOException {
+        final HttpClient httpClient = HttpClientBuilder.create().build();
+        final StringEntity params = new StringEntity(sendTextBody);
+
+        final HttpUriRequest request = RequestBuilder.create(String.valueOf(method))
+                .setUri(uri)
+                .addHeader("content-type", "text/html")
+                .setCharset(StandardCharsets.UTF_8)
+                .setEntity(params)
+                .build();
+
+        return httpClient.execute(request);
+    }
+
+    @Test
+    void start() throws InterruptedException {
+
+        final DssWebSocketServer dssWebSocketServer = new DssWebSocketServer("127.0.0.1", 8181);
+
+        stopDssWebSocketServerAfterActivated(dssWebSocketServer, 10, 15);
+
+        dssWebSocketServer.start();
+
+        assertTrue(dssWebSocketServer.isShutdown());
+    }
+
+    @Test
+    void test() throws InterruptedException {
+        final DssWebSocketServer dssWebSocketServer = new DssWebSocketServer("127.0.0.1", 8181);
+        stopDssWebSocketServerAfterActivated(dssWebSocketServer, 10 ,15);
+
+        dssWebSocketServer.start();
+
+        assertTrue(dssWebSocketServer.isShutdown());
+    }
+
+    @Test
+    void testSsl() throws Exception {
+        final PrivateKey privateKey = loadPrivateKeyFromFile(loadFromTestResources("ssl/private.der"));
+        final X509Certificate certificate = loadX509CertificateFromFile(loadFromTestResources("ssl/private.crt"));
+
+        final SslContext sslContext = SslContextBuilder.forServer(privateKey, SSL_PASSWORD, certificate).build();
+
+        final DssWebSocketServer dssWebSocketServer = new DssWebSocketServer("127.0.0.1", 8181, DssLogLevel.INFO, true, sslContext);
+        stopDssWebSocketServerAfterActivated(dssWebSocketServer, 10 ,15);
+
+        dssWebSocketServer.start();
+
+        assertTrue(dssWebSocketServer.isShutdown());
+    }
+
+    @Test
+    @Timeout(value = 15)
+    void testGetRequest() throws IOException, InterruptedException {
+        final DssWebSocketServer dssWebSocketServer = new DssWebSocketServer("127.0.0.1", 8181);
+
+        startOnDssTextWebSocketServer(dssWebSocketServer);
+        await().until(dssWebSocketServer::isActivated);
+
+        final String uri = "http://127.0.0.1:8181";
+        final String sendTextBody = "Hello";
+
+        HttpResponse response = sendTextRequest(uri, HttpMethod.GET, sendTextBody);
+
+        String receiveTextBody = EntityUtils.toString(response.getEntity(), "UTF-8");
+
+        assertEquals(sendTextBody, receiveTextBody);
+
+        dssWebSocketServer.stop();
+
+        assertTrue(dssWebSocketServer.isShutdown());
+    }
+
+    @Test
+    @Timeout(value = 15)
+    void testWebsocketGetRequest() throws Exception {
+        final DssWebSocketServer dssWebSocketServer = new DssWebSocketServer("127.0.0.1", 8181);
+
+        startOnDssTextWebSocketServer(dssWebSocketServer);
+        await().until(dssWebSocketServer::isActivated);
+
+        final URI uri = URI.create("ws://127.0.0.1:8181/websocket");
+
+        WebSocketClient client = new WebSocketClient();
+        MyWebSocket socket = new MyWebSocket();
+
+        client.start();
+
+        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        Future<Session> future = client.connect(socket, uri, request);
+        Session session = future.get();
+        UpgradeResponse response = session.getUpgradeResponse();
+        assertEquals("Upgrade", response.getHeader("Connection"));
+        assertEquals("websocket", response.getHeader("Upgrade"));
+        assertEquals("Switching Protocols", response.getStatusReason());
+        assertEquals(101, response.getStatusCode());
+
+        session.close();
+
+        dssWebSocketServer.stop();
+
+        assertTrue(dssWebSocketServer.isShutdown());
+    }
+
+    @WebSocket
+    public class MyWebSocket {
+
+        @OnWebSocketConnect
+        public void onConnect(Session session) throws IOException {
+            session.getRemote().sendString("Hello server");
+        }
+
+        @OnWebSocketMessage
+        public void onMessage(String message) {
+            System.out.println("Message from Server: " + message);
+        }
+
+        @OnWebSocketClose
+        public void onClose(int statusCode, String reason) {
+            System.out.println("WebSocket Closed. Code:" + statusCode);
+        }
+
+    }
+}


### PR DESCRIPTION
I added websocket handler first. I will add service interface later.

### Websocket Process

1. Open Handshake
: It occurs in `DssHttpRequestHandler.java`
- Client's handshake request : HTTP Upgrade Request using only GET method

```
GET /chat HTTP/1.1
Host: dssserver.example.com
Upgrade: websocket
Connection: Upgrade
Sec-WebSocket-Key: ScmyStFFNlK9TVHteROMKA==
Origin: <http://example.com>
Sec-WebSocket-Version: 13
```

- Server's handshake response : Accept websocket connection with value combined websocket-key & GUID

```
HTTP/1.1 101 Switching Protocols
upgrade: websocket
connection: upgrade
sec-websocket-accept: t3gjBK9ILNyvtnyC+vneMlV98g4=
```

2. Sending and Receiving Data Frame (Current: Echo message)
: It occurs in `DssWebSocketHandler.java`
- If client sends message to dss server, dss server receives message called Websocket Frame.  

3. Close connection

---

I tested it works fine using Jetty websocket client or Echo Test ([https://www.websocket.org/echo.html](https://www.websocket.org/echo.html))

Here is test logs.

```
[INFO ] [DssWebSocketServer.java]start(66) : Server Started
[INFO ] [DssWebSocketChannelInitializer.java]initChannel(20) : Try to initChannel
[INFO ] [DssHttpRequestHandler.java]handleHttpRequest(47) : Request URI: /websocket
[INFO ] [DssHttpRequestHandler.java]handleHttpRequest(65) : Request WebSocket Protocol
[INFO ] [DssHttpRequestHandler.java]handleHandshake(95) : Handshake Start
[INFO ] [DssHttpRequestHandler.java]handleHandshake(98) : ws://localhost:8181/websocket
[INFO ] [DssHttpRequestHandler.java]handleHandshake(106) : Handshake Success
[INFO ] [DssWebSocketHandler.java]channelRead(17) : Client Channel : [id: 0x70e76c8c, L:/127.0.0.1:8181 - R:/127.0.0.1:55702]
[INFO ] [DssWebSocketHandler.java]channelRead(23) : TextWebSocketFrame Received
[INFO ] [DssWebSocketHandler.java]channelRead(28) : Received Message : Hello! Dss Server
[INFO ] [DssWebSocketHandler.java]channelRead(17) : Client Channel : [id: 0x70e76c8c, L:/127.0.0.1:8181 - R:/127.0.0.1:55702]
[INFO ] [DssWebSocketHandler.java]channelRead(36) : CloseWebSocketFrame Received
[INFO ] [DssWebSocketHandler.java]channelRead(39) : ReasonText : 
[INFO ] [DssWebSocketHandler.java]channelRead(40) : StatusCode : 1000
[INFO ] [DssWebSocketChannelInitializer.java]initChannel(20) : Try to initChannel
[INFO ] [DssHttpRequestHandler.java]handleHttpRequest(47) : Request URI: /websocket?encoding=text
[INFO ] [DssHttpRequestHandler.java]handleHttpRequest(65) : Request WebSocket Protocol
[INFO ] [DssHttpRequestHandler.java]handleHandshake(95) : Handshake Start
[INFO ] [DssHttpRequestHandler.java]handleHandshake(98) : ws://127.0.0.1:8181/websocket
[INFO ] [DssHttpRequestHandler.java]handleHandshake(106) : Handshake Success
[INFO ] [DssWebSocketHandler.java]channelRead(17) : Client Channel : [id: 0xfed0f797, L:/127.0.0.1:8181 - R:/127.0.0.1:55731]
[INFO ] [DssWebSocketHandler.java]channelRead(23) : TextWebSocketFrame Received
[INFO ] [DssWebSocketHandler.java]channelRead(28) : Received Message : Hello
```

### Code Review

- I want to add `WebSocketServerProtocolHandler` but It can not handle http message in Echo Test ([https://www.websocket.org/echo.html](https://www.websocket.org/echo.html)).
Because this handler replaces HttpServerCodec into WebSocketFrameCodec.
If I use this handler, I don't need to write handshake method.
- I want to handle websocket endpoint well.
ex) URI: "/websocket" or "/websocket?encoding=text" or "/websocket/example"
These endpoints all mean "request websocket"?

Thank you for reading.